### PR TITLE
fix: remove unnecessary common module

### DIFF
--- a/apps/challenges/src/app/multilevel-data-passing/mldp-children/mldp-children.component.ts
+++ b/apps/challenges/src/app/multilevel-data-passing/mldp-children/mldp-children.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, input } from '@angular/core';
 import { MldpGrandChildrenComponent } from '../mldp-grand-children/mldp-grand-children.component';
 
@@ -9,7 +8,7 @@ import { MldpGrandChildrenComponent } from '../mldp-grand-children/mldp-grand-ch
     <h3>Children</h3>
     <angular-challenges-mldp-grand-children [data]="data()" />
   `,
-  imports: [CommonModule, MldpGrandChildrenComponent],
+  imports: [MldpGrandChildrenComponent],
 })
 export class MldpChildrenComponent {
   data = input.required<string>();

--- a/apps/challenges/src/app/multilevel-data-passing/mldp-grand-children/mldp-grand-children.component.ts
+++ b/apps/challenges/src/app/multilevel-data-passing/mldp-grand-children/mldp-grand-children.component.ts
@@ -1,10 +1,9 @@
-import { CommonModule } from '@angular/common';
 import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'angular-challenges-mldp-grand-children',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   template: `
     <h4>Grand Child</h4>
     <p>Data from parent: {{ data() }}</p>

--- a/apps/challenges/src/app/multilevel-data-passing/multilevel-data-passing.component.ts
+++ b/apps/challenges/src/app/multilevel-data-passing/multilevel-data-passing.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { MldpChildrenComponent } from './mldp-children/mldp-children.component';
 
@@ -35,6 +34,6 @@ import { MldpChildrenComponent } from './mldp-children/mldp-children.component';
     <h2>ROOT</h2>
     <angular-challenges-mldp-children [data]="'ROOT'" />
   `,
-  imports: [CommonModule, MldpChildrenComponent],
+  imports: [MldpChildrenComponent],
 })
 export default class MultilevelDataPassingComponent {}


### PR DESCRIPTION
I don't think the `CommonModule` is really necessary for this challenge and it can be safely removed. 

`CommonModule` can also be removed from `control-child-layout`, as it is unused in that challenge at the start as well.   