### PR TITLE
fix: add missing core theme

### DIFF
--- a/apps/challenges/project.json
+++ b/apps/challenges/project.json
@@ -20,7 +20,7 @@
           "apps/challenges/src/favicon.ico",
           "apps/challenges/src/assets"
         ],
-        "styles": ["apps/challenges/src/styles.scss"],
+        "styles": ["apps/challenges/src/styles.scss", "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css"],
         "scripts": []
       },
       "configurations": {


### PR DESCRIPTION
Without Angular Material core theme, the tabs don't render correctly.  You get a solid black line under both tabs.  